### PR TITLE
Feature/trip list pagination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,12 @@
 			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.tngtech.java</groupId>
+			<artifactId>junit-dataprovider</artifactId>
+			<version>1.13.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/lt/vu/trip/controller/TripController.java
+++ b/src/main/java/lt/vu/trip/controller/TripController.java
@@ -3,6 +3,7 @@ package lt.vu.trip.controller;
 import lt.vu.trip.entity.Trip;
 import lt.vu.trip.entity.request.TripRequestParams;
 import lt.vu.trip.entity.response.TripListResponse;
+import lt.vu.trip.service.trip.TripSearchCriteria;
 import lt.vu.trip.service.trip.TripService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -20,12 +21,35 @@ public class TripController {
 
 	@GetMapping("")
 	public ResponseEntity<TripListResponse> getAllTrips(@Valid TripRequestParams requestParams) {
-		Page<Trip> trips = tripService.getAll(requestParams.getPage(), requestParams.getResultsPerPage());
-		TripListResponse response = TripListResponse.builder()
-				.totalPageCount(trips.getTotalPages())
-				.totalResultsCount(trips.getTotalElements())
-				.results(trips.getContent())
-				.build();
+		TripSearchCriteria criteria = buildSearchCriteriaFromRequest(requestParams);
+		Page<Trip> trips = tripService.getAll(requestParams.getPage(), requestParams.getResultsPerPage(), criteria);
+		TripListResponse response = buildListResponseFromPage(trips);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/my")
+	public ResponseEntity<TripListResponse> getCurrentUserTrips(@Valid TripRequestParams requestParams) {
+		TripSearchCriteria criteria = buildSearchCriteriaFromRequest(requestParams);
+		Page<Trip> trips = tripService.getCurrentUserParticipatingIn(
+				requestParams.getPage(), requestParams.getResultsPerPage(), criteria);
+		TripListResponse response = buildListResponseFromPage(trips);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/invitation")
+	public ResponseEntity<TripListResponse> getInvitations(@Valid TripRequestParams requestParams) {
+		TripSearchCriteria criteria = buildSearchCriteriaFromRequest(requestParams);
+		Page<Trip> trips = tripService.getCurrentUserInvitedIn(
+				requestParams.getPage(), requestParams.getResultsPerPage(), criteria);
+		TripListResponse response = buildListResponseFromPage(trips);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/organized")
+	public ResponseEntity<TripListResponse> getOrganized(@Valid TripRequestParams requestParams) {
+		TripSearchCriteria criteria = buildSearchCriteriaFromRequest(requestParams);
+		Page<Trip> trips = tripService.getOrganizedByCurrentUser(requestParams.getPage(), requestParams.getResultsPerPage(), criteria);
+		TripListResponse response = buildListResponseFromPage(trips);
 		return ResponseEntity.ok(response);
 	}
 
@@ -33,5 +57,20 @@ public class TripController {
 	public ResponseEntity<Trip> createTrip(@RequestBody Trip trip) {
 		tripService.createNew(trip);
 		return ResponseEntity.ok(trip);
+	}
+
+	private TripSearchCriteria buildSearchCriteriaFromRequest(TripRequestParams requestParams) {
+		return TripSearchCriteria.builder()
+				.startDate(requestParams.getStartDate())
+				.endDate((requestParams.getEndDate()))
+				.build();
+	}
+
+	private TripListResponse buildListResponseFromPage(Page<Trip> trips) {
+		return TripListResponse.builder()
+				.totalPageCount(trips.getTotalPages())
+				.totalResultsCount(trips.getTotalElements())
+				.results(trips.getContent())
+				.build();
 	}
 }

--- a/src/main/java/lt/vu/trip/controller/TripController.java
+++ b/src/main/java/lt/vu/trip/controller/TripController.java
@@ -1,11 +1,13 @@
 package lt.vu.trip.controller;
 
 import lt.vu.trip.entity.Trip;
+import lt.vu.trip.entity.request.TripRequestParams;
 import lt.vu.trip.service.trip.TripService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -16,7 +18,7 @@ public class TripController {
 	private TripService tripService;
 
 	@GetMapping("")
-	public ResponseEntity<List<Trip>> getAllTrips() {
+	public ResponseEntity<List<Trip>> getAllTrips(@Valid TripRequestParams requestParams) {
 		List<Trip> trips = tripService.getAll();
 		return ResponseEntity.ok(trips);
 	}

--- a/src/main/java/lt/vu/trip/controller/TripController.java
+++ b/src/main/java/lt/vu/trip/controller/TripController.java
@@ -61,8 +61,10 @@ public class TripController {
 
 	private TripSearchCriteria buildSearchCriteriaFromRequest(TripRequestParams requestParams) {
 		return TripSearchCriteria.builder()
-				.startDate(requestParams.getStartDate())
-				.endDate((requestParams.getEndDate()))
+				.startDateFrom(requestParams.getStartDateFrom())
+				.startDateTo(requestParams.getStartDateTo())
+				.endDateFrom((requestParams.getEndDateFrom()))
+				.endDateTo((requestParams.getEndDateTo()))
 				.build();
 	}
 

--- a/src/main/java/lt/vu/trip/controller/TripController.java
+++ b/src/main/java/lt/vu/trip/controller/TripController.java
@@ -2,6 +2,7 @@ package lt.vu.trip.controller;
 
 import lt.vu.trip.entity.Trip;
 import lt.vu.trip.entity.request.TripRequestParams;
+import lt.vu.trip.entity.response.TripListResponse;
 import lt.vu.trip.service.trip.TripService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -9,7 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.List;
 
 @RestController
 @RequestMapping("/trip")
@@ -19,9 +19,14 @@ public class TripController {
 	private TripService tripService;
 
 	@GetMapping("")
-	public ResponseEntity<List<Trip>> getAllTrips(@Valid TripRequestParams requestParams) {
+	public ResponseEntity<TripListResponse> getAllTrips(@Valid TripRequestParams requestParams) {
 		Page<Trip> trips = tripService.getAll(requestParams.getPage(), requestParams.getResultsPerPage());
-		return ResponseEntity.ok(trips.getContent());
+		TripListResponse response = TripListResponse.builder()
+				.totalPageCount(trips.getTotalPages())
+				.totalResultsCount(trips.getTotalElements())
+				.results(trips.getContent())
+				.build();
+		return ResponseEntity.ok(response);
 	}
 
 	@PostMapping("")

--- a/src/main/java/lt/vu/trip/controller/TripController.java
+++ b/src/main/java/lt/vu/trip/controller/TripController.java
@@ -4,6 +4,7 @@ import lt.vu.trip.entity.Trip;
 import lt.vu.trip.entity.request.TripRequestParams;
 import lt.vu.trip.service.trip.TripService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,8 +20,8 @@ public class TripController {
 
 	@GetMapping("")
 	public ResponseEntity<List<Trip>> getAllTrips(@Valid TripRequestParams requestParams) {
-		List<Trip> trips = tripService.getAll();
-		return ResponseEntity.ok(trips);
+		Page<Trip> trips = tripService.getAll(requestParams.getPage(), requestParams.getResultsPerPage());
+		return ResponseEntity.ok(trips.getContent());
 	}
 
 	@PostMapping("")

--- a/src/main/java/lt/vu/trip/entity/Trip.java
+++ b/src/main/java/lt/vu/trip/entity/Trip.java
@@ -1,6 +1,7 @@
 package lt.vu.trip.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
 
 import javax.persistence.*;
@@ -27,6 +28,7 @@ public class Trip {
 	private User organizer;
 
 	@OneToMany(mappedBy = "trip")
+	@JsonManagedReference
 	private List<TripParticipation> tripParticipations = new ArrayList<>();
 
 	private LocalDate startDate;

--- a/src/main/java/lt/vu/trip/entity/TripParticipation.java
+++ b/src/main/java/lt/vu/trip/entity/TripParticipation.java
@@ -1,5 +1,6 @@
 package lt.vu.trip.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 
@@ -21,6 +22,7 @@ public class TripParticipation {
 
 	@NotNull
 	@ManyToOne
+	@JsonBackReference
 	private Trip trip;
 
 	@NotNull

--- a/src/main/java/lt/vu/trip/entity/request/TripRequestParams.java
+++ b/src/main/java/lt/vu/trip/entity/request/TripRequestParams.java
@@ -4,9 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.validation.constraints.NotNull;
 import java.io.Serializable;
+import java.time.LocalDate;
 
 @Data
 @Builder
@@ -19,4 +21,10 @@ public class TripRequestParams implements Serializable {
 
 	@NotNull
 	private int resultsPerPage = 10;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	private LocalDate startDate;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	private LocalDate endDate;
 }

--- a/src/main/java/lt/vu/trip/entity/request/TripRequestParams.java
+++ b/src/main/java/lt/vu/trip/entity/request/TripRequestParams.java
@@ -1,0 +1,22 @@
+package lt.vu.trip.entity.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripRequestParams implements Serializable {
+
+	@NotNull
+	private int page = 1;
+
+	@NotNull
+	private int resultsPerPage = 10;
+}

--- a/src/main/java/lt/vu/trip/entity/request/TripRequestParams.java
+++ b/src/main/java/lt/vu/trip/entity/request/TripRequestParams.java
@@ -23,8 +23,14 @@ public class TripRequestParams implements Serializable {
 	private int resultsPerPage = 10;
 
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
-	private LocalDate startDate;
+	private LocalDate startDateFrom;
 
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
-	private LocalDate endDate;
+	private LocalDate startDateTo;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	private LocalDate endDateFrom;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	private LocalDate endDateTo;
 }

--- a/src/main/java/lt/vu/trip/entity/response/TripListResponse.java
+++ b/src/main/java/lt/vu/trip/entity/response/TripListResponse.java
@@ -1,0 +1,23 @@
+package lt.vu.trip.entity.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lt.vu.trip.entity.Trip;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripListResponse implements Serializable {
+
+	private int totalPageCount;
+
+	private long totalResultsCount;
+
+	private List<Trip> results;
+}

--- a/src/main/java/lt/vu/trip/repository/TripRepository.java
+++ b/src/main/java/lt/vu/trip/repository/TripRepository.java
@@ -2,6 +2,7 @@ package lt.vu.trip.repository;
 
 import lt.vu.trip.entity.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface TripRepository extends JpaRepository<Trip, Long> {
+public interface TripRepository extends JpaRepository<Trip, Long>, JpaSpecificationExecutor<Trip> {
 }

--- a/src/main/java/lt/vu/trip/service/auth/jwt/CustomUserDetailsService.java
+++ b/src/main/java/lt/vu/trip/service/auth/jwt/CustomUserDetailsService.java
@@ -1,11 +1,13 @@
 package lt.vu.trip.service.auth.jwt;
 
 import lt.vu.trip.repository.UserRepository;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
+@Primary
 @Component
 public class CustomUserDetailsService implements UserDetailsService {
 

--- a/src/main/java/lt/vu/trip/service/trip/TripSearchCriteria.java
+++ b/src/main/java/lt/vu/trip/service/trip/TripSearchCriteria.java
@@ -1,0 +1,26 @@
+package lt.vu.trip.service.trip;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lt.vu.trip.entity.TripParticipationStatus;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripSearchCriteria {
+
+	private LocalDate startDate;
+
+	private LocalDate endDate;
+
+	private Long organizerId;
+
+	private Long participantId;
+
+	private TripParticipationStatus participationStatus;
+}

--- a/src/main/java/lt/vu/trip/service/trip/TripSearchCriteria.java
+++ b/src/main/java/lt/vu/trip/service/trip/TripSearchCriteria.java
@@ -14,9 +14,13 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class TripSearchCriteria {
 
-	private LocalDate startDate;
+	private LocalDate startDateFrom;
 
-	private LocalDate endDate;
+	private LocalDate startDateTo;
+
+	private LocalDate endDateFrom;
+
+	private LocalDate endDateTo;
 
 	private Long organizerId;
 

--- a/src/main/java/lt/vu/trip/service/trip/TripService.java
+++ b/src/main/java/lt/vu/trip/service/trip/TripService.java
@@ -4,7 +4,13 @@ import lt.vu.trip.entity.Trip;
 import org.springframework.data.domain.Page;
 
 public interface TripService {
-	Page<Trip> getAll(int page, int resultsPerPage);
+	Page<Trip> getAll(int page, int resultsPerPage, TripSearchCriteria criteria);
+
+	Page<Trip> getOrganizedByCurrentUser(int page, int resultsPerPage, TripSearchCriteria criteria);
+
+	Page<Trip> getCurrentUserParticipatingIn(int page, int resultsPerPage, TripSearchCriteria criteria);
+
+	Page<Trip> getCurrentUserInvitedIn(int page, int resultsPerPage, TripSearchCriteria criteria);
 
 	boolean createNew(Trip trip);
 }

--- a/src/main/java/lt/vu/trip/service/trip/TripService.java
+++ b/src/main/java/lt/vu/trip/service/trip/TripService.java
@@ -1,11 +1,10 @@
 package lt.vu.trip.service.trip;
 
 import lt.vu.trip.entity.Trip;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
 
 public interface TripService {
-	List<Trip> getAll();
+	Page<Trip> getAll(int page, int resultsPerPage);
 
 	boolean createNew(Trip trip);
 }

--- a/src/main/java/lt/vu/trip/service/trip/TripServiceImpl.java
+++ b/src/main/java/lt/vu/trip/service/trip/TripServiceImpl.java
@@ -1,7 +1,10 @@
 package lt.vu.trip.service.trip;
 
 import lt.vu.trip.entity.Trip;
+import lt.vu.trip.entity.TripParticipationStatus;
+import lt.vu.trip.entity.User;
 import lt.vu.trip.repository.TripRepository;
+import lt.vu.trip.service.user.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,15 +18,42 @@ public class TripServiceImpl implements TripService {
 	@Autowired
 	private TripRepository repo;
 
-	public Page<Trip> getAll(int page, int resultsPerPage) {
-		Pageable pageable = getDefaultPageable(page, resultsPerPage);
-		Page<Trip> trips = repo.findAll(pageable);
-		return trips;
+	@Autowired
+	private UserService userService;
+
+	public Page<Trip> getAll(int page, int resultsPerPage, TripSearchCriteria criteria) {
+		return this.getList(page, resultsPerPage, criteria);
+	}
+
+	public Page<Trip> getOrganizedByCurrentUser(int page, int resultsPerPage, TripSearchCriteria criteria) {
+		User currentUser = userService.getCurrentUser();
+		criteria.setOrganizerId(currentUser.getId());
+		return this.getList(page, resultsPerPage, criteria);
+	}
+
+	public Page<Trip> getCurrentUserParticipatingIn(int page, int resultsPerPage, TripSearchCriteria criteria) {
+		User currentUser = userService.getCurrentUser();
+		criteria.setParticipantId(currentUser.getId());
+		criteria.setParticipationStatus(TripParticipationStatus.ACCEPTED);
+		return this.getList(page, resultsPerPage, criteria);
+	}
+
+	public Page<Trip> getCurrentUserInvitedIn(int page, int resultsPerPage, TripSearchCriteria criteria) {
+		User currentUser = userService.getCurrentUser();
+		criteria.setParticipantId(currentUser.getId());
+		criteria.setParticipationStatus(TripParticipationStatus.INVITED);
+		return this.getList(page, resultsPerPage, criteria);
 	}
 
 	public boolean createNew(Trip trip) {
 		repo.saveAndFlush(trip);
 		return true;
+	}
+
+	private Page<Trip> getList(int page, int resultsPerPage, TripSearchCriteria criteria) {
+		Pageable pageable = getDefaultPageable(page, resultsPerPage);
+		Page<Trip> trips = repo.findAll(TripSpecifications.findByCriteria(criteria), pageable);
+		return trips;
 	}
 
 	private Pageable getDefaultPageable(int page, int resultsPerPage) {

--- a/src/main/java/lt/vu/trip/service/trip/TripServiceImpl.java
+++ b/src/main/java/lt/vu/trip/service/trip/TripServiceImpl.java
@@ -3,9 +3,11 @@ package lt.vu.trip.service.trip;
 import lt.vu.trip.entity.Trip;
 import lt.vu.trip.repository.TripRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 public class TripServiceImpl implements TripService {
@@ -13,12 +15,20 @@ public class TripServiceImpl implements TripService {
 	@Autowired
 	private TripRepository repo;
 
-	public List<Trip> getAll() {
-		return repo.findAll();
+	public Page<Trip> getAll(int page, int resultsPerPage) {
+		Pageable pageable = getDefaultPageable(page, resultsPerPage);
+		Page<Trip> trips = repo.findAll(pageable);
+		return trips;
 	}
 
 	public boolean createNew(Trip trip) {
 		repo.saveAndFlush(trip);
 		return true;
+	}
+
+	private Pageable getDefaultPageable(int page, int resultsPerPage) {
+		// pages here are numbered from 0
+		Pageable pageable = PageRequest.of(page - 1, resultsPerPage, Sort.by("startDate").and(Sort.by("endDate")));
+		return pageable;
 	}
 }

--- a/src/main/java/lt/vu/trip/service/trip/TripSpecifications.java
+++ b/src/main/java/lt/vu/trip/service/trip/TripSpecifications.java
@@ -1,0 +1,46 @@
+package lt.vu.trip.service.trip;
+
+import lt.vu.trip.entity.Trip;
+import lt.vu.trip.entity.TripParticipation;
+import lt.vu.trip.entity.User;
+import org.springframework.data.jpa.domain.Specification;
+
+import javax.persistence.criteria.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TripSpecifications {
+
+	public static Specification<Trip> findByCriteria(final TripSearchCriteria searchCriteria) {
+		return new Specification<Trip>() {
+			@Override
+			public Predicate toPredicate(Root<Trip> trip, CriteriaQuery<?> query, CriteriaBuilder cb) {
+
+				List<Predicate> predicates = new ArrayList<Predicate>();
+
+				if (searchCriteria.getStartDate() != null) {
+					predicates.add(cb.greaterThanOrEqualTo(trip.<LocalDate>get("startDate"), searchCriteria.getStartDate()));
+				}
+				if (searchCriteria.getEndDate() != null) {
+					predicates.add(cb.lessThanOrEqualTo(trip.<LocalDate>get("endDate"), searchCriteria.getEndDate()));
+				}
+				if (searchCriteria.getOrganizerId() != null) {
+					final Join<Trip, User> organizer = trip.join("organizer");
+					predicates.add(cb.equal(organizer.<Long>get("id"), searchCriteria.getOrganizerId()));
+				}
+				if (searchCriteria.getParticipantId() != null) {
+					final Join<Trip, TripParticipation> participation = trip.join("tripParticipations");
+					final Join<TripParticipation, User> user = participation.join("participant");
+
+					predicates.add(cb.equal(user.<Long>get("id"), searchCriteria.getParticipantId()));
+
+					if (searchCriteria.getParticipationStatus() != null) {
+						predicates.add(cb.equal(participation.<Long>get("status"), searchCriteria.getParticipationStatus()));
+					}
+				}
+				return cb.and(predicates.toArray(new Predicate[] {}));
+			}
+		};
+	}
+}

--- a/src/main/java/lt/vu/trip/service/trip/TripSpecifications.java
+++ b/src/main/java/lt/vu/trip/service/trip/TripSpecifications.java
@@ -19,11 +19,17 @@ public class TripSpecifications {
 
 				List<Predicate> predicates = new ArrayList<Predicate>();
 
-				if (searchCriteria.getStartDate() != null) {
-					predicates.add(cb.greaterThanOrEqualTo(trip.<LocalDate>get("startDate"), searchCriteria.getStartDate()));
+				if (searchCriteria.getStartDateFrom() != null) {
+					predicates.add(cb.greaterThanOrEqualTo(trip.<LocalDate>get("startDate"), searchCriteria.getStartDateFrom()));
 				}
-				if (searchCriteria.getEndDate() != null) {
-					predicates.add(cb.lessThanOrEqualTo(trip.<LocalDate>get("endDate"), searchCriteria.getEndDate()));
+				if (searchCriteria.getStartDateTo() != null) {
+					predicates.add(cb.lessThanOrEqualTo(trip.<LocalDate>get("startDate"), searchCriteria.getStartDateTo()));
+				}
+				if (searchCriteria.getEndDateFrom() != null) {
+					predicates.add(cb.greaterThanOrEqualTo(trip.<LocalDate>get("endDate"), searchCriteria.getEndDateFrom()));
+				}
+				if (searchCriteria.getEndDateTo() != null) {
+					predicates.add(cb.lessThanOrEqualTo(trip.<LocalDate>get("endDate"), searchCriteria.getEndDateTo()));
 				}
 				if (searchCriteria.getOrganizerId() != null) {
 					final Join<Trip, User> organizer = trip.join("organizer");

--- a/src/main/java/lt/vu/trip/service/user/UserService.java
+++ b/src/main/java/lt/vu/trip/service/user/UserService.java
@@ -1,0 +1,7 @@
+package lt.vu.trip.service.user;
+
+import lt.vu.trip.entity.User;
+
+public interface UserService {
+	User getCurrentUser();
+}

--- a/src/main/java/lt/vu/trip/service/user/UserServiceImpl.java
+++ b/src/main/java/lt/vu/trip/service/user/UserServiceImpl.java
@@ -1,0 +1,14 @@
+package lt.vu.trip.service.user;
+
+import lt.vu.trip.entity.User;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+class UserServiceImpl implements UserService {
+
+	public User getCurrentUser() {
+		User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		return user;
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,7 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 
 spring.liquibase.changeLog=classpath:db/changelog/db.changelog-master.yaml
+
+logging.level.root=WARN
+logging.level.org.springframework.web=WARN
+logging.level.org.hibernate=WARN

--- a/src/test/java/lt/vu/trip/service/user/TripServiceImplDataProvider.java
+++ b/src/test/java/lt/vu/trip/service/user/TripServiceImplDataProvider.java
@@ -1,0 +1,42 @@
+package lt.vu.trip.service.user;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TripServiceImplDataProvider {
+
+	@DataProvider()
+	public static Object[][] getAllParamsData() {
+		Object[][] data = new Object[][] {
+			// page, results per page, start date from, start date to, end date from, end date to,
+			// expected element count, expected page count, expected ids of trips
+			{1, 100, new String[]{null, null, null, null}, 4, 1, new Long[]{1L, 2L, 3L, 4L}}, // get all
+			{1, 2, new String[]{null, null, null, null}, 4, 2, new Long[]{2L, 3L}}, // first page, but not all elements
+			{2, 3, new String[]{null, null, null, null}, 4, 2, new Long[]{4L}}, // second page
+			{1, 100, new String[]{"2019-04-20", null, null, null}, 2, 1, new Long[]{1L, 4L}}, // get all, start date limited
+			{1, 100, new String[]{"2020-04-20", null, null, null}, 0, 0, new Long[]{}}, // get all, no results
+			{2, 2, new String[]{"2019-04-19", null, null, null}, 3, 2, new Long[]{4L}}, // start date limited, second page
+			{1, 10, new String[]{"2019-04-19", "2019-04-22", null, null}, 2, 1, new Long[]{1L, 2L}}, // start date limited
+			{1, 10, new String[]{null, null, "2019-04-26", "2019-10-25"}, 3, 1, new Long[]{1L, 2L, 3L}}, // end date limited
+			{1, 10, new String[]{"2019-04-19", "2019-12-01", "2019-05-27", "2019-12-02"}, 2, 1, new Long[]{2L, 4L}}, // both dates limited
+		};
+		for (Object[] line : data) {
+			List<LocalDate> dateList = new ArrayList<>();
+			for (String date : (String[])line[2]) {
+				if (date == null) {
+					dateList.add(null);
+				} else {
+					dateList.add(LocalDate.parse(date));
+				}
+			}
+			line[2] = dateList;
+			line[5] = new ArrayList<Long>(Arrays.asList((Long[])line[5]));
+		}
+		return data;
+	}
+
+}

--- a/src/test/java/lt/vu/trip/service/user/TripServiceImplDataProvider.java
+++ b/src/test/java/lt/vu/trip/service/user/TripServiceImplDataProvider.java
@@ -25,18 +25,44 @@ public class TripServiceImplDataProvider {
 			{1, 10, new String[]{"2019-04-19", "2019-12-01", "2019-05-27", "2019-12-02"}, 2, 1, new Long[]{2L, 4L}}, // both dates limited
 		};
 		for (Object[] line : data) {
-			List<LocalDate> dateList = new ArrayList<>();
-			for (String date : (String[])line[2]) {
-				if (date == null) {
-					dateList.add(null);
-				} else {
-					dateList.add(LocalDate.parse(date));
-				}
-			}
-			line[2] = dateList;
-			line[5] = new ArrayList<Long>(Arrays.asList((Long[])line[5]));
+			line[2] = buildLocalDateList((String[])line[2]);
+			line[5] = buildLongIdsList((Long[])line[5]);
 		}
 		return data;
+	}
+
+	@DataProvider()
+	public static Object[][] getOrganizedByCurrentUserData() {
+		Object[][] data = new Object[][] {
+				// page, results per page, start date from, start date to, end date from, end date to, current user id
+				// expected element count, expected page count, expected ids of trips
+				{1, 100, new String[]{null, null, null, null}, 1, 3, 1, new Long[]{1L, 2L, 4L}}, // get all
+				{1, 100, new String[]{null, null, null, null}, 3, 0, 0, new Long[]{}}, // get all
+				{1, 100, new String[]{"2020-04-20", null, null, null}, 1, 0, 0, new Long[]{}}, // get all, no results
+				{1, 2, new String[]{"2019-02-19", null, null, null}, 2, 1, 1, new Long[]{3L}}, // start date limited, second page
+				{1, 10, new String[]{"2019-04-19", "2019-12-01", "2019-05-27", "2019-12-02"}, 1, 2, 1, new Long[]{2L, 4L}}, // both dates limited
+		};
+		for (Object[] line : data) {
+			line[2] = buildLocalDateList((String[])line[2]);
+			line[6] = buildLongIdsList((Long[])line[6]);
+		}
+		return data;
+	}
+
+	private static List<LocalDate> buildLocalDateList(String[] dates){
+		List<LocalDate> dateList = new ArrayList<>();
+		for (String date : dates) {
+			if (date == null) {
+				dateList.add(null);
+			} else {
+				dateList.add(LocalDate.parse(date));
+			}
+		}
+		return dateList;
+	}
+
+	private static List<Long> buildLongIdsList(Long[] ids) {
+		return new ArrayList<Long>(Arrays.asList(ids));
 	}
 
 }

--- a/src/test/java/lt/vu/trip/service/user/TripServiceImplDataProvider.java
+++ b/src/test/java/lt/vu/trip/service/user/TripServiceImplDataProvider.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public class TripServiceImplDataProvider {
 
-	@DataProvider()
+	@DataProvider
 	public static Object[][] getAllParamsData() {
 		Object[][] data = new Object[][] {
 			// page, results per page, start date from, start date to, end date from, end date to,
@@ -25,13 +25,13 @@ public class TripServiceImplDataProvider {
 			{1, 10, new String[]{"2019-04-19", "2019-12-01", "2019-05-27", "2019-12-02"}, 2, 1, new Long[]{2L, 4L}}, // both dates limited
 		};
 		for (Object[] line : data) {
-			line[2] = buildLocalDateList((String[])line[2]);
-			line[5] = buildLongIdsList((Long[])line[5]);
+			line[2] = buildLocalDateList((String[]) line[2]);
+			line[5] = buildLongIdsList((Long[]) line[5]);
 		}
 		return data;
 	}
 
-	@DataProvider()
+	@DataProvider
 	public static Object[][] getOrganizedByCurrentUserData() {
 		Object[][] data = new Object[][] {
 				// page, results per page, start date from, start date to, end date from, end date to, current user id
@@ -43,13 +43,13 @@ public class TripServiceImplDataProvider {
 				{1, 10, new String[]{"2019-04-19", "2019-12-01", "2019-05-27", "2019-12-02"}, 1, 2, 1, new Long[]{2L, 4L}}, // both dates limited
 		};
 		for (Object[] line : data) {
-			line[2] = buildLocalDateList((String[])line[2]);
-			line[6] = buildLongIdsList((Long[])line[6]);
+			line[2] = buildLocalDateList((String[]) line[2]);
+			line[6] = buildLongIdsList((Long[]) line[6]);
 		}
 		return data;
 	}
 
-	@DataProvider()
+	@DataProvider
 	public static Object[][] getCurrentUserParticipatingInData() {
 		Object[][] data = new Object[][] {
 				// page, results per page, start date from, start date to, end date from, end date to, current user id
@@ -60,13 +60,13 @@ public class TripServiceImplDataProvider {
 				{2, 1, new String[]{"2019-02-19", null, null, null}, 2, 2, 2, new Long[]{1L}}, // start date limited
 		};
 		for (Object[] line : data) {
-			line[2] = buildLocalDateList((String[])line[2]);
-			line[6] = buildLongIdsList((Long[])line[6]);
+			line[2] = buildLocalDateList((String[]) line[2]);
+			line[6] = buildLongIdsList((Long[]) line[6]);
 		}
 		return data;
 	}
 
-	@DataProvider()
+	@DataProvider
 	public static Object[][] getCurrentUserInvitedInData() {
 		Object[][] data = new Object[][] {
 				// page, results per page, start date from, start date to, end date from, end date to, current user id
@@ -77,13 +77,13 @@ public class TripServiceImplDataProvider {
 				{2, 1, new String[]{"2019-02-19", null, null, null}, 3, 1, 1, new Long[]{}}, // start date limited
 		};
 		for (Object[] line : data) {
-			line[2] = buildLocalDateList((String[])line[2]);
-			line[6] = buildLongIdsList((Long[])line[6]);
+			line[2] = buildLocalDateList((String[]) line[2]);
+			line[6] = buildLongIdsList((Long[]) line[6]);
 		}
 		return data;
 	}
 
-	private static List<LocalDate> buildLocalDateList(String[] dates){
+	private static List<LocalDate> buildLocalDateList(String[] dates) {
 		List<LocalDate> dateList = new ArrayList<>();
 		for (String date : dates) {
 			if (date == null) {

--- a/src/test/java/lt/vu/trip/service/user/TripServiceImplDataProvider.java
+++ b/src/test/java/lt/vu/trip/service/user/TripServiceImplDataProvider.java
@@ -39,8 +39,42 @@ public class TripServiceImplDataProvider {
 				{1, 100, new String[]{null, null, null, null}, 1, 3, 1, new Long[]{1L, 2L, 4L}}, // get all
 				{1, 100, new String[]{null, null, null, null}, 3, 0, 0, new Long[]{}}, // get all
 				{1, 100, new String[]{"2020-04-20", null, null, null}, 1, 0, 0, new Long[]{}}, // get all, no results
-				{1, 2, new String[]{"2019-02-19", null, null, null}, 2, 1, 1, new Long[]{3L}}, // start date limited, second page
+				{1, 2, new String[]{"2019-02-19", null, null, null}, 2, 1, 1, new Long[]{3L}}, // start date limited,
 				{1, 10, new String[]{"2019-04-19", "2019-12-01", "2019-05-27", "2019-12-02"}, 1, 2, 1, new Long[]{2L, 4L}}, // both dates limited
+		};
+		for (Object[] line : data) {
+			line[2] = buildLocalDateList((String[])line[2]);
+			line[6] = buildLongIdsList((Long[])line[6]);
+		}
+		return data;
+	}
+
+	@DataProvider()
+	public static Object[][] getCurrentUserParticipatingInData() {
+		Object[][] data = new Object[][] {
+				// page, results per page, start date from, start date to, end date from, end date to, current user id
+				// expected element count, expected page count, expected ids of trips
+				{1, 100, new String[]{null, "2020-04-22", null, null}, 1, 1, 1, new Long[]{3L}}, // get all
+				{1, 100, new String[]{null, null, null, null}, 4, 0, 0, new Long[]{}}, // get all
+				{1, 100, new String[]{"2020-04-20", null, null, null}, 2, 0, 0, new Long[]{}}, // get all, no results
+				{2, 1, new String[]{"2019-02-19", null, null, null}, 2, 2, 2, new Long[]{1L}}, // start date limited
+		};
+		for (Object[] line : data) {
+			line[2] = buildLocalDateList((String[])line[2]);
+			line[6] = buildLongIdsList((Long[])line[6]);
+		}
+		return data;
+	}
+
+	@DataProvider()
+	public static Object[][] getCurrentUserInvitedInData() {
+		Object[][] data = new Object[][] {
+				// page, results per page, start date from, start date to, end date from, end date to, current user id
+				// expected element count, expected page count, expected ids of trips
+				{1, 100, new String[]{null, "2020-04-22", null, null}, 1, 0, 0, new Long[]{}}, // get all
+				{1, 100, new String[]{null, null, null, null}, 4, 0, 0, new Long[]{}}, // get all
+				{1, 100, new String[]{"2019-04-20", null, null, null}, 2, 1, 1, new Long[]{4L}}, // get all, no results
+				{2, 1, new String[]{"2019-02-19", null, null, null}, 3, 1, 1, new Long[]{}}, // start date limited
 		};
 		for (Object[] line : data) {
 			line[2] = buildLocalDateList((String[])line[2]);

--- a/src/test/java/lt/vu/trip/service/user/TripServiceImplIntegrationTest.java
+++ b/src/test/java/lt/vu/trip/service/user/TripServiceImplIntegrationTest.java
@@ -64,7 +64,7 @@ public class TripServiceImplIntegrationTest {
 	@Test
 	@UseDataProvider(value = "getCurrentUserParticipatingInData", location = TripServiceImplDataProvider.class)
 	public void testGetCurrentUserParticipatingIn(int page, int resultsPerPage, List<LocalDate> filterDates, int currentUserId,
-											  int expectedElementCount, int expectedPageCount, List<Long> expectedIds) {
+			int expectedElementCount, int expectedPageCount, List<Long> expectedIds) {
 		Mockito.when(userService.getCurrentUser()).thenReturn(User.builder().id((long) currentUserId).build());
 		Page<Trip> trips = tripService.getCurrentUserParticipatingIn(page, resultsPerPage, buildSearchCriteria(filterDates));
 		assertTripPage(trips, expectedElementCount, expectedPageCount, expectedIds);
@@ -73,7 +73,7 @@ public class TripServiceImplIntegrationTest {
 	@Test
 	@UseDataProvider(value = "getCurrentUserInvitedInData", location = TripServiceImplDataProvider.class)
 	public void testGetCurrentUserInvitedIn(int page, int resultsPerPage, List<LocalDate> filterDates, int currentUserId,
-												  int expectedElementCount, int expectedPageCount, List<Long> expectedIds) {
+			int expectedElementCount, int expectedPageCount, List<Long> expectedIds) {
 		Mockito.when(userService.getCurrentUser()).thenReturn(User.builder().id((long) currentUserId).build());
 		Page<Trip> trips = tripService.getCurrentUserInvitedIn(page, resultsPerPage, buildSearchCriteria(filterDates));
 		assertTripPage(trips, expectedElementCount, expectedPageCount, expectedIds);

--- a/src/test/java/lt/vu/trip/service/user/TripServiceImplIntegrationTest.java
+++ b/src/test/java/lt/vu/trip/service/user/TripServiceImplIntegrationTest.java
@@ -1,6 +1,5 @@
 package lt.vu.trip.service.user;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import lt.vu.trip.entity.Trip;
@@ -26,12 +25,8 @@ import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static io.restassured.RestAssured.when;
 
 @RunWith(DataProviderRunner.class)
 @SpringBootTest
@@ -61,8 +56,26 @@ public class TripServiceImplIntegrationTest {
 	@UseDataProvider(value = "getOrganizedByCurrentUserData", location = TripServiceImplDataProvider.class)
 	public void testGetOrganizedByCurrentUser(int page, int resultsPerPage, List<LocalDate> filterDates, int currentUserId,
 			int expectedElementCount, int expectedPageCount, List<Long> expectedIds) {
-		Mockito.when(userService.getCurrentUser()).thenReturn(User.builder().id(new Long(currentUserId)).build());
+		Mockito.when(userService.getCurrentUser()).thenReturn(User.builder().id((long) currentUserId).build());
 		Page<Trip> trips = tripService.getOrganizedByCurrentUser(page, resultsPerPage, buildSearchCriteria(filterDates));
+		assertTripPage(trips, expectedElementCount, expectedPageCount, expectedIds);
+	}
+
+	@Test
+	@UseDataProvider(value = "getCurrentUserParticipatingInData", location = TripServiceImplDataProvider.class)
+	public void testGetCurrentUserParticipatingIn(int page, int resultsPerPage, List<LocalDate> filterDates, int currentUserId,
+											  int expectedElementCount, int expectedPageCount, List<Long> expectedIds) {
+		Mockito.when(userService.getCurrentUser()).thenReturn(User.builder().id((long) currentUserId).build());
+		Page<Trip> trips = tripService.getCurrentUserParticipatingIn(page, resultsPerPage, buildSearchCriteria(filterDates));
+		assertTripPage(trips, expectedElementCount, expectedPageCount, expectedIds);
+	}
+
+	@Test
+	@UseDataProvider(value = "getCurrentUserInvitedInData", location = TripServiceImplDataProvider.class)
+	public void testGetCurrentUserInvitedIn(int page, int resultsPerPage, List<LocalDate> filterDates, int currentUserId,
+												  int expectedElementCount, int expectedPageCount, List<Long> expectedIds) {
+		Mockito.when(userService.getCurrentUser()).thenReturn(User.builder().id((long) currentUserId).build());
+		Page<Trip> trips = tripService.getCurrentUserInvitedIn(page, resultsPerPage, buildSearchCriteria(filterDates));
 		assertTripPage(trips, expectedElementCount, expectedPageCount, expectedIds);
 	}
 

--- a/src/test/java/lt/vu/trip/service/user/TripServiceImplIntegrationTest.java
+++ b/src/test/java/lt/vu/trip/service/user/TripServiceImplIntegrationTest.java
@@ -1,0 +1,89 @@
+package lt.vu.trip.service.user;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import lt.vu.trip.entity.Trip;
+import lt.vu.trip.service.trip.TripSearchCriteria;
+import lt.vu.trip.service.trip.TripService;
+import lt.vu.trip.service.trip.TripServiceImpl;
+import org.hamcrest.Matchers;
+import org.hamcrest.collection.IsIterableContainingInAnyOrder;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Page;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RunWith(DataProviderRunner.class)
+@SpringBootTest
+public class TripServiceImplIntegrationTest {
+
+	@ClassRule
+	public static final SpringClassRule SPRING_CLASS_RULE= new SpringClassRule();
+
+	@Rule
+	public final SpringMethodRule springMethodRule = new SpringMethodRule();
+
+	@Autowired
+	private TripService tripService;
+
+	@MockBean
+	private UserService userService;
+
+	@Test
+	@UseDataProvider("getAllParamsData")
+	public void testGetAll(int page, int resultsPerPage, LocalDate startDate, LocalDate endDate,
+						int expectedElementCount, int expectedPageCount, List<Long> expectedIds) {
+		TripSearchCriteria criteria = TripSearchCriteria.builder().startDate(startDate).endDate(endDate).build();
+
+		Page<Trip> trips = tripService.getAll(page, resultsPerPage, criteria);
+
+		Assert.assertEquals(expectedElementCount, trips.getTotalElements());
+		Assert.assertEquals(expectedPageCount, trips.getTotalPages());
+		Assert.assertThat(extractIdsFromTrips(trips.getContent()), IsIterableContainingInAnyOrder.containsInAnyOrder(
+				expectedIds.stream().map(Matchers::equalTo).collect(Collectors.toList())
+		));
+	}
+
+	@DataProvider
+	public static Object[][] getAllParamsData() {
+		return new Object[][]{
+			// page, results per page, start date, end date, expected element count,
+			// expected page count, expected ids of trips
+			{1, 100, null, null, 4, 1, new ArrayList<>(Arrays.asList(1L, 2L, 3L, 4L))}, // get all
+			{1, 2, null, null, 4, 2, new ArrayList<>(Arrays.asList(2L, 3L))}, // first page, but not all elements
+			{2, 3, null, null, 4, 2, new ArrayList<>(Arrays.asList(4L))}, // second page
+			{1, 100, LocalDate.parse("2019-04-20"), null, 2, 1, new ArrayList<>(Arrays.asList(1L, 4L))}, // get all, start date limited
+			{1, 100, LocalDate.parse("2020-04-20"), null, 0, 0, new ArrayList<>(Arrays.asList())}, // get all, no results
+			{2, 2, LocalDate.parse("2019-04-19"), null, 3, 2, new ArrayList<>(Arrays.asList(4L))}, // start date limited, second page
+			{1, 10, LocalDate.parse("2019-04-19"), LocalDate.parse("2019-04-26"), 1, 1, new ArrayList<>(Arrays.asList(1L))}, // both dates limited
+		};
+	}
+
+	private List<Long> extractIdsFromTrips(List<Trip> trips) {
+		return trips.stream().map(Trip::getId).collect(Collectors.toList());
+	}
+
+	@TestConfiguration
+	static class TripServiceImplTestContextConfiguration {
+		@Bean
+		public TripService tripService() {
+			return new TripServiceImpl();
+		}
+	}
+}

--- a/src/test/java/lt/vu/trip/service/user/TripServiceImplIntegrationTest.java
+++ b/src/test/java/lt/vu/trip/service/user/TripServiceImplIntegrationTest.java
@@ -4,6 +4,7 @@ import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import lt.vu.trip.entity.Trip;
+import lt.vu.trip.entity.User;
 import lt.vu.trip.service.trip.TripSearchCriteria;
 import lt.vu.trip.service.trip.TripService;
 import lt.vu.trip.service.trip.TripServiceImpl;
@@ -14,6 +15,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -28,6 +30,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static io.restassured.RestAssured.when;
 
 @RunWith(DataProviderRunner.class)
 @SpringBootTest
@@ -48,8 +52,17 @@ public class TripServiceImplIntegrationTest {
 	@Test
 	@UseDataProvider(value = "getAllParamsData", location = TripServiceImplDataProvider.class)
 	public void testGetAll(int page, int resultsPerPage, List<LocalDate> filterDates,
-						int expectedElementCount, int expectedPageCount, List<Long> expectedIds) {
+			int expectedElementCount, int expectedPageCount, List<Long> expectedIds) {
 		Page<Trip> trips = tripService.getAll(page, resultsPerPage, buildSearchCriteria(filterDates));
+		assertTripPage(trips, expectedElementCount, expectedPageCount, expectedIds);
+	}
+
+	@Test
+	@UseDataProvider(value = "getOrganizedByCurrentUserData", location = TripServiceImplDataProvider.class)
+	public void testGetOrganizedByCurrentUser(int page, int resultsPerPage, List<LocalDate> filterDates, int currentUserId,
+			int expectedElementCount, int expectedPageCount, List<Long> expectedIds) {
+		Mockito.when(userService.getCurrentUser()).thenReturn(User.builder().id(new Long(currentUserId)).build());
+		Page<Trip> trips = tripService.getOrganizedByCurrentUser(page, resultsPerPage, buildSearchCriteria(filterDates));
 		assertTripPage(trips, expectedElementCount, expectedPageCount, expectedIds);
 	}
 

--- a/src/test/java/lt/vu/trip/service/user/TripServiceImplIntegrationTest.java
+++ b/src/test/java/lt/vu/trip/service/user/TripServiceImplIntegrationTest.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 public class TripServiceImplIntegrationTest {
 
 	@ClassRule
-	public static final SpringClassRule SPRING_CLASS_RULE= new SpringClassRule();
+	public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
 
 	@Rule
 	public final SpringMethodRule springMethodRule = new SpringMethodRule();

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -6,3 +6,9 @@ spring.datasource.url=jdbc:h2:file:~/test
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
+
+spring.jpa.hibernate.ddl-auto=create-drop
+
+logging.level.root=WARN
+logging.level.org.springframework.web=WARN
+logging.level.org.hibernate=WARN

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,0 +1,22 @@
+INSERT INTO users (id, password, username) VALUES
+	(1, '', 'a'),
+	(2, '', 'b'),
+	(3, '', 'c'),
+	(4, '', 'd')
+;
+
+INSERT INTO trips (id, start_date, end_date, organizer_id) VALUES
+	(1, '2019-04-22', '2019-04-26', 1),
+	(2, '2019-04-19', '2019-05-27', 1),
+	(3, '2019-02-19', '2019-10-25', 2),
+	(4, '2019-12-01', '2019-12-02', 1)
+;
+
+INSERT INTO trip_participations (id, status, participant_id, trip_id) VALUES
+	(1, 'ACCEPTED', 2, 1),
+	(2, 'INVITED', 3, 1),
+	(3, 'REJECTED', 3, 1),
+	(4, 'ACCEPTED', 1, 3),
+	(5, 'ACCEPTED', 2, 3),
+	(6, 'INVITED', 2, 4)
+;


### PR DESCRIPTION
This is a huge feature set, take it seriously.
4 GET endpoints ("trip", "trip/my", "trip/invitation", "trip/organized") were created. Every of them returns a list of trips. Every of these 4 endpoints accepts these parameters/filters:
- page (default 1)
- resultsPerPage (default 10)
- startDateFrom (trip start date greater or equal to)
- startDateTo 
- endDateFrom
- endDateTo

In the response there are always a list of trips (obviously), total elements count and total pages count.
Trips are always ordered by start date in ascending order (because we don't need ordering in the web).

So the request could be like that:
/trip?startDateFrom=2019-04-22&endDateFrom=2019-04-25
/trip/organized?page=2?resultsPerPage=20&startDateTo=2019-04-22